### PR TITLE
Update spree_marketplace.gemspec

### DIFF
--- a/spree_marketplace.gemspec
+++ b/spree_marketplace.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'stripe'
-  s.add_dependency 'spree_core', '~> 2.3.0'
+  s.add_dependency 'solidus_core', '~> 1.1.0'
   s.add_dependency 'spree_drop_ship'
 
   s.add_development_dependency 'capybara', '~> 2.2'


### PR DESCRIPTION
changed from "spree_core" to "solidus_core", and the changed the version dependancy