### PR TITLE
remove unused spree_payment_methods.environment from marketplace_conf…

### DIFF
--- a/app/models/spree/marketplace_configuration.rb
+++ b/app/models/spree/marketplace_configuration.rb
@@ -8,7 +8,7 @@ module Spree
     preference :stripe_publishable_key, :string, default: -> {
       if ActiveRecord::Base.connection.table_exists?(:spree_payment_methods)
         # If you are using Stripe as a credit card processor we automatically lookup your api key to use for payments.
-        Spree::PaymentMethod.where(type: 'Spree::Gateway::StripeGateway', environment: Rails.env).first.try(:preferred_publishable_key)
+        Spree::PaymentMethod.where(type: 'Spree::Gateway::StripeGateway').first.try(:preferred_publishable_key)
       else
         nil
       end
@@ -17,7 +17,7 @@ module Spree
     preference :stripe_secret_key, :string, default: -> {
       if ActiveRecord::Base.connection.table_exists?(:spree_payment_methods)
         # If you are using Stripe as a credit card processor we automatically lookup your api key to use for payments.
-        Spree::PaymentMethod.where(type: 'Spree::Gateway::StripeGateway', environment: Rails.env).first.try(:preferred_secret_key)
+        Spree::PaymentMethod.where(type: 'Spree::Gateway::StripeGateway').first.try(:preferred_secret_key)
       else
         nil
       end


### PR DESCRIPTION
…iguration.rb to continue installation of spree_marketplace on solidus

1. run error msg
tt@mark-ThinkPad-Edge:~/solidmp$ bundle exec rails g spree_marketplace:install
/home/tt/.rvm/gems/ruby-2.1.2/gems/sqlite3-1.3.11/lib/sqlite3/database.rb:91:in `initialize': SQLite3::SQLException: no such column: spree_payment_methods.environment: SELECT  "spree_payment_methods".* FROM "spree_payment_methods" WHERE "spree_payment_methods"."deleted_at" IS NULL AND "spree_payment_methods"."type" = ? AND "spree_payment_methods"."environment" = 'development'  ORDER BY "spree_payment_methods"."id" ASC LIMIT 1 (ActiveRecord::StatementInvalid)
	from /home/tt/.rvm/gems/ruby-2.1.2/gems/sqlite3-1.3.11/lib/sqlite3/database.rb:91:in `new'

2.enviroment usage in old version: https://guides.spreecommerce.com/user/payment_methods.htm

3. bugfix by spree which remove spree_payment_methods.environment: 
solildus#bugfix: https://github.com/solidusio/solidus/pull/248

4. where the spree_payment_methods.environment is used for marketplace (below environment: Rails.env)
remove the environment: Rails.env here